### PR TITLE
Allow database names that start with '_'

### DIFF
--- a/doc/couch_client-database.md
+++ b/doc/couch_client-database.md
@@ -108,7 +108,7 @@ $cookie = $client->setSessionCookie("AuthSession=Y291Y2g6NENGNDgzNz")->getSessio
 
 ### isValidDatabaseName()
 
-Database names on CouchDB have restrictions : only lowercase characters (a-z), digits (0-9), and any of the characters _, $, (, ), +, -, and / are allowed. The name has to start with a lowercase letter (a-z). To test if a given database name is valid, use the static **isValidDatabaseName()** couchClient method.
+Database names on CouchDB have restrictions : only lowercase characters (a-z), digits (0-9), and any of the characters _, $, (, ), +, -, and / are allowed. The name has to start with a lowercase letter (a-z) or an underscore (_). To test if a given database name is valid, use the static **isValidDatabaseName()** couchClient method.
 
 Note: to allow access to system databases (_users, _replicator), those names added to special list and will return `true`.
 

--- a/src/CouchClient.php
+++ b/src/CouchClient.php
@@ -287,9 +287,7 @@ class CouchClient extends Couch
 	 */
 	public static function isValidDatabaseName($dbname)
 	{
-		if ($dbname == '_users')
-			return true;
-		if (preg_match('/^[a-z][a-z0-9_$()+\/-]*$/', $dbname))
+		if (preg_match('/^[_a-z][a-z0-9_$()+\/-]*$/', $dbname))
 			return true;
 		return false;
 	}

--- a/tests/CouchClientTest.php
+++ b/tests/CouchClientTest.php
@@ -156,7 +156,8 @@ EOT
 			"a-zer_ty" => true,
 			"a(zert)y" => true,
 			"4azerty" => false,
-			"a_$()+-/test" => true
+            "a_$()+-/test" => true,
+            "_azerty" => true
 		);
 		foreach ($matches as $key => $val) {
 			$this->assertEquals($val, CouchClient::isValidDatabaseName($key));


### PR DESCRIPTION
I've just amended the regex in isValidDatabaseName in CouchClient.php to allow for databases beginning with an underscore.  I've updated the corresponding test as well.