### PR TITLE
Fix license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "driver"
     ],
     "homepage": "https://github.com/PHP-on-Couch/PHP-on-Couch",
-    "license": "GPL-3.0-or-later",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "Michael Bailly",


### PR DESCRIPTION
The included license for the project is the LGPL license, but composer.json referred to the GPL instead. Composer also [supports](https://getcomposer.org/doc/04-schema.md#license) the LGPL.