### PR TITLE
Fixing dynamic property deprecation for PHP 8.2

### DIFF
--- a/src/Couch.php
+++ b/src/Couch.php
@@ -58,6 +58,11 @@ class Couch
     protected $options = null;
 
     /**
+     * @var \PHPOnCouch\Adapter\CouchHttpAdapterInterface
+     */
+    protected $adapter = null;
+
+    /**
      * class constructor
      *
      * @param string $dsn CouchDB Data Source Name


### PR DESCRIPTION
Adding undefined property `$adapter` to avoid deprecated issue introduced on PHP 8.2

https://wiki.php.net/rfc/deprecate_dynamic_properties
`Deprecated: Creation of dynamic property PHPOnCouch\CouchClient::$adapter is deprecated in /var/www/vendor/php-on-couch/php-on-couch/src/Couch.php on line 126`